### PR TITLE
Add APK change detection helper

### DIFF
--- a/App_Analysis/apk_hashing.py
+++ b/App_Analysis/apk_hashing.py
@@ -1,0 +1,60 @@
+"""Utilities for computing APK hashes.
+
+These helpers are primarily used to detect whether an APK file has
+changed between versions. Calculating and comparing SHA-256 digests is
+often easier than parsing version metadata from the manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Dict
+
+from Utils.logging_utils import log_manager
+
+
+def _hash_file(path: str) -> str:
+    """Return the SHA-256 hash for a single file."""
+    if not os.path.isfile(path):
+        log_manager.log_warning(f"File not found: {path}")
+        return ""
+
+    sha256 = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                sha256.update(chunk)
+        return sha256.hexdigest()
+    except Exception as e:
+        log_manager.log_exception(f"Failed to hash {path}: {e}")
+        return ""
+
+
+@log_manager.log_call("info")
+def calculate_apk_hash(path: str) -> str:
+    """Compute the SHA-256 hash of an APK file."""
+    return _hash_file(path)
+
+
+@log_manager.log_call("info")
+def apk_changed(path: str, known_hash: str) -> bool:
+    """Return ``True`` if the APK hash differs from ``known_hash``."""
+    current = calculate_apk_hash(path)
+    return current != known_hash
+
+
+@log_manager.log_call("info")
+def hash_apk_directory(directory: str) -> Dict[str, str]:
+    """Recursively hash all APK files under ``directory``.
+
+    The returned mapping can be stored to compare against future builds
+    or to correlate hashes with specific manifest versions.
+    """
+    hashes: Dict[str, str] = {}
+    for root_dir, _dirs, files in os.walk(directory):
+        for name in files:
+            if name.lower().endswith(".apk"):
+                file_path = os.path.join(root_dir, name)
+                hashes[file_path] = _hash_file(file_path)
+    return hashes

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Stonehaven is a command-line suite for inspecting Android devices and APK files.
 - Static APK permission extraction and risk scoring
 - Detection of excessive or suspicious permission combinations
 - Security misconfiguration detection (API keys, cleartext traffic, storage)
+- Fast SHA-256 hashing of APK files for integrity checks
 - CVSS-scored static scans of decompiled APK directories
 - CVSS v3.0 scoring utilities for reported issues
 - Export scan reports to Markdown and CSV
@@ -38,6 +39,13 @@ Stonehaven is a command-line suite for inspecting Android devices and APK files.
    python main.py
    ```
 3. Use the menu to scan for devices or connect to a device for a detailed summary.
+4. Compute an APK hash:
+   ```bash
+   python -c "from App_Analysis.apk_hashing import calculate_apk_hash; print(calculate_apk_hash('myapp.apk'))"
+   ```
+   The digest can be stored alongside your build or manifest version
+   number to quickly detect unexpected changes in future releases.
+
 
 ## Project Layout
 

--- a/Utils/app_utils/about_app.py
+++ b/Utils/app_utils/about_app.py
@@ -38,6 +38,11 @@ def show_about():
     print("   - Hash integrity verification (SHA256)")
     print("   - Integration with ADB and platform-tools")
     print("   - Modular design for extensibility")
+    print("  Example hash check:")
+    print("    >>> from App_Analysis.apk_hashing import calculate_apk_hash")
+    print("    >>> calculate_apk_hash('myapp.apk')")
+    print("    # store this hash with the manifest version to detect changes")
+
 
     display_utils.print_spacer()
 


### PR DESCRIPTION
## Summary
- document new use-case for hashing APK files
- add `apk_changed` helper function for quick integrity checks
- log warning when hashed file is missing
- clarify README and About screen instructions

## Testing
- `python -m py_compile App_Analysis/apk_hashing.py Utils/app_utils/about_app.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6888e45ecccc832793cb771d22a4e14e